### PR TITLE
Feature for scheduling preferred replica leader election

### DIFF
--- a/app/controllers/PreferredReplicaElection.scala
+++ b/app/controllers/PreferredReplicaElection.scala
@@ -5,7 +5,7 @@
 
 package controllers
 
-import features.{ApplicationFeatures, KMPreferredReplicaElectionFeature}
+import features.{ApplicationFeatures, KMPreferredReplicaElectionFeature, KMScheduleLeaderElectionFeature}
 import kafka.manager.ApiError
 import kafka.manager.features.ClusterFeatures
 import models.FollowLink
@@ -15,6 +15,7 @@ import play.api.data.Form
 import play.api.data.Forms._
 import play.api.data.validation.{Constraint, Invalid, Valid}
 import play.api.i18n.I18nSupport
+import play.api.libs.json.{JsObject, Json}
 import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -82,6 +83,105 @@ class PreferredReplicaElection (val cc: ControllerComponents, val kafkaManagerCo
             )).withHeaders("X-Frame-Options" -> "SAMEORIGIN"))
         }
       )
+    }
+  }
+
+  def handleScheduledIntervalAPI(cluster: String): Action[AnyContent] = Action.async { implicit request =>
+    featureGate(KMScheduleLeaderElectionFeature) {
+      val interval = kafkaManager.pleCancellable.get(cluster).map(_._2).getOrElse(0)
+      Future(Ok(Json.obj("scheduledInterval" -> interval))
+        .withHeaders("X-Frame-Options" -> "SAMEORIGIN"))
+    }
+  }
+
+  def scheduleRunElection(c: String) = Action.async { implicit request =>
+    var status_string: String = ""
+    var timePeriod: Int = 0
+    if(kafkaManager.pleCancellable.contains(c)){
+      status_string = "Scheduler is running"
+      timePeriod = kafkaManager.pleCancellable(c)._2
+    }
+    else {
+      status_string = "Scheduler is not running"
+    }
+    kafkaManager.getTopicList(c).map { errorOrStatus =>
+      Ok(views.html.scheduleLeaderElection(c,errorOrStatus, status_string, timePeriod)).withHeaders("X-Frame-Options" -> "SAMEORIGIN")
+    }
+  }
+
+  def handleScheduleRunElection(c: String) = Action.async { implicit request =>
+    var status_string: String = ""
+    var timeIntervalMinutes = request.body.asFormUrlEncoded.get("timePeriod")(0).toInt
+    if(!kafkaManager.pleCancellable.contains(c)){
+      kafkaManager.getTopicList(c).flatMap { errorOrTopicList =>
+        errorOrTopicList.fold({ e =>
+          Future.successful(-\/(e))
+        }, { topicList =>
+          kafkaManager.schedulePreferredLeaderElection(c, topicList.list.toSet, timeIntervalMinutes)
+        })
+      }
+      status_string = "Scheduler started"
+    }
+    else{
+      status_string = "Scheduler already scheduled"
+      timeIntervalMinutes = kafkaManager.pleCancellable(c)._2
+    }
+    kafkaManager.getTopicList(c).map { errorOrStatus =>
+      Ok(views.html.scheduleLeaderElection(c, errorOrStatus, status_string, timeIntervalMinutes)).withHeaders("X-Frame-Options" -> "SAMEORIGIN")
+    }
+  }
+
+  def cancelScheduleRunElection(c: String) = Action.async { implicit request =>
+    var status_string: String = ""
+    if(kafkaManager.pleCancellable.contains(c)){
+      kafkaManager.cancelPreferredLeaderElection(c)
+      status_string = "Scheduler stopped"
+    }
+    else {
+      status_string = "Scheduler already not running"
+    }
+    kafkaManager.getTopicList(c).map { errorOrStatus =>
+      Ok(views.html.scheduleLeaderElection(c,errorOrStatus,status_string, 0)).withHeaders("X-Frame-Options" -> "SAMEORIGIN")
+    }
+  }
+
+  def handleScheduleRunElectionAPI(c: String) = Action.async { implicit request =>
+    // ToDo: Refactor out common part from handleScheduleRunElection
+    featureGate(KMScheduleLeaderElectionFeature) {
+
+      var timePeriod = request.body.asInstanceOf[AnyContentAsJson].json.asInstanceOf[JsObject].values.toList(0).toString().toInt
+      var status_string: String = ""
+      if(!kafkaManager.pleCancellable.contains(c)){
+        kafkaManager.getTopicList(c).flatMap { errorOrTopicList =>
+          errorOrTopicList.fold({ e =>
+            Future.successful(-\/(e))
+          }, { topicList =>
+            kafkaManager.schedulePreferredLeaderElection(c, topicList.list.toSet, timePeriod)
+          })
+        }
+        status_string = "Scheduler started"
+      }
+      else{
+        status_string = "Scheduler already scheduled"
+        timePeriod = kafkaManager.pleCancellable(c)._2
+      }
+      Future(
+        Ok(Json.obj(
+          "scheduledInterval" -> timePeriod, "message" -> status_string
+        )).withHeaders("X-Frame-Options" -> "SAMEORIGIN")
+      )
+    }
+  }
+
+  def cancelScheduleRunElectionAPI(c: String) = Action.async { implicit request =>
+    // ToDo: Refactor out common part from cancelScheduleRunElection
+    featureGate(KMScheduleLeaderElectionFeature) {
+      val status_string: String = if(kafkaManager.pleCancellable.contains(c)){
+        kafkaManager.cancelPreferredLeaderElection(c)
+        "Scheduler stopped"
+      }
+      else "Scheduler already not running"
+      Future(Ok(Json.obj("scheduledInterval" -> 0, "message" -> status_string)).withHeaders("X-Frame-Options" -> "SAMEORIGIN"))
     }
   }
 }

--- a/app/controllers/PreferredReplicaElection.scala
+++ b/app/controllers/PreferredReplicaElection.scala
@@ -132,14 +132,11 @@ class PreferredReplicaElection (val cc: ControllerComponents, val kafkaManagerCo
   }
 
   def cancelScheduleRunElection(c: String) = Action.async { implicit request =>
-    var status_string: String = ""
-    if(kafkaManager.pleCancellable.contains(c)){
+    val status_string: String = if(kafkaManager.pleCancellable.contains(c)){
       kafkaManager.cancelPreferredLeaderElection(c)
-      status_string = "Scheduler stopped"
+      "Scheduler stopped"
     }
-    else {
-      status_string = "Scheduler already not running"
-    }
+    else "Scheduler already not running"
     kafkaManager.getTopicList(c).map { errorOrStatus =>
       Ok(views.html.scheduleLeaderElection(c,errorOrStatus,status_string, 0)).withHeaders("X-Frame-Options" -> "SAMEORIGIN")
     }

--- a/app/features/ApplicationFeature.scala
+++ b/app/features/ApplicationFeature.scala
@@ -16,6 +16,7 @@ sealed trait ApplicationFeature extends KMFeature
 case object KMClusterManagerFeature extends ApplicationFeature
 case object KMTopicManagerFeature extends ApplicationFeature
 case object KMPreferredReplicaElectionFeature extends ApplicationFeature
+case object KMScheduleLeaderElectionFeature extends ApplicationFeature
 case object KMReassignPartitionsFeature extends ApplicationFeature
 case object KMBootstrapClusterConfigFeature extends ApplicationFeature
 

--- a/app/kafka/manager/KafkaManager.scala
+++ b/app/kafka/manager/KafkaManager.scala
@@ -963,12 +963,11 @@ class KafkaManager(akkaConfig: Config) extends Logging {
 
   def initialiseSchedulePreferredLeaderElection(): Unit = {
     implicit val ec = apiExecutionContext
+    implicit val formats = org.json4s.DefaultFormats
 
     var temp: Map[String, Int] = Map.empty
     val x = system.actorSelection(kafkaManagerActor).ask(KSGetScheduleLeaderElection)
     x.foreach { schedule =>
-      implicit val formats = org.json4s.DefaultFormats
-
       temp = parse(schedule.toString).extract[Map[String, Int]]
       for ((cluster, timeInterval) <- temp) {
         schedulePreferredLeaderElection(cluster, Set(), timeInterval)

--- a/app/kafka/manager/actor/KafkaManagerActor.scala
+++ b/app/kafka/manager/actor/KafkaManagerActor.scala
@@ -14,6 +14,7 @@ import kafka.manager.actor.cluster.{ClusterManagerActor, ClusterManagerActorConf
 import kafka.manager.base.{LongRunningPoolConfig, BaseZkPath, CuratorAwareActor, BaseQueryCommandActor}
 import kafka.manager.model.{ClusterTuning, ClusterConfig, CuratorConfig}
 import kafka.manager.model.ActorModel.CMShutdown
+import kafka.manager.utils.ZkUtils
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.recipes.cache.PathChildrenCache.StartMode
 import org.apache.curator.framework.recipes.cache.{PathChildrenCache, PathChildrenCacheEvent, PathChildrenCacheListener}
@@ -228,6 +229,9 @@ class KafkaManagerActor(kafkaManagerConfig: KafkaManagerActorConfig)
 
       case KMGetAllClusters =>
         sender ! KMClusterList(clusterConfigMap.values.toIndexedSeq, pendingClusterConfigMap.values.toIndexedSeq)
+
+      case KSGetScheduleLeaderElection =>
+        sender ! ZkUtils.readDataMaybeNull(curator, ZkUtils.SchedulePreferredLeaderElectionPath)._1.getOrElse("{}")
 
       case KMGetClusterConfig(name) =>
         sender ! KMClusterConfigResult(Try {

--- a/app/kafka/manager/model/ActorModel.scala
+++ b/app/kafka/manager/model/ActorModel.scala
@@ -89,6 +89,7 @@ object ActorModel {
   case class CMUpdateTopicConfig(topic: String, config: Properties, readVersion: Int) extends CommandRequest
   case class CMDeleteTopic(topic: String) extends CommandRequest
   case class CMRunPreferredLeaderElection(topics: Set[String]) extends CommandRequest
+  case class CMSchedulePreferredLeaderElection(schedule: Map[String, Int]) extends CommandRequest
   case class CMRunReassignPartition(topics: Set[String], forceSet: Set[ForceReassignmentCommand]) extends CommandRequest
   case class CMGeneratePartitionAssignments(topics: Set[String], brokers: Set[Int], replicationFactor: Option[Int] = None) extends CommandRequest
   case class CMManualPartitionAssignments(assignments: List[(String, List[(Int, List[Int])])]) extends CommandRequest
@@ -169,6 +170,7 @@ object ActorModel {
   case object KSGetTopicsLastUpdateMillis extends KSRequest
   case object KSGetPreferredLeaderElection extends KSRequest
   case object KSGetReassignPartition extends KSRequest
+  case object KSGetScheduleLeaderElection extends KSRequest
   case class KSEndPreferredLeaderElection(millis: Long) extends CommandRequest
   case class KSUpdatePreferredLeaderElection(millis: Long, json: String) extends CommandRequest
   case class KSEndReassignPartition(millis: Long) extends CommandRequest

--- a/app/kafka/manager/utils/ZkUtils.scala
+++ b/app/kafka/manager/utils/ZkUtils.scala
@@ -42,6 +42,7 @@ object ZkUtils {
   val DeleteTopicsPath = "/admin/delete_topics"
   val PreferredReplicaLeaderElectionPath = "/admin/preferred_replica_election"
   val AdminPath = "/admin"
+  val SchedulePreferredLeaderElectionPath = AdminPath + "/schedule_leader_election"
 
   def getTopicPath(topic: String): String = {
     BrokerTopicsPath + "/" + topic

--- a/app/kafka/manager/utils/zero81/SchedulePreferredLeaderElectionCommand.scala
+++ b/app/kafka/manager/utils/zero81/SchedulePreferredLeaderElectionCommand.scala
@@ -1,0 +1,32 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.manager.utils.zero81
+
+import grizzled.slf4j.Logging
+import kafka.manager.utils._
+import org.apache.curator.framework.CuratorFramework
+
+object SchedulePreferredLeaderElectionCommand extends Logging {
+
+  def writeScheduleLeaderElectionData(curator: CuratorFramework, schedule: Map[String, Int]): Unit = {
+    val jsonData = toJson(schedule)
+
+    ZkUtils.updatePersistentPath(curator, ZkUtils.SchedulePreferredLeaderElectionPath, jsonData)
+    logger.info("Updating ZK scheduler with %s".format(jsonData))
+  }
+}

--- a/app/models/navigation/BreadCrumbs.scala
+++ b/app/models/navigation/BreadCrumbs.scala
@@ -74,6 +74,9 @@ object BreadCrumbs {
     "Preferred Replica Election" -> IndexedSeq(
       "Clusters".baseRouteBreadCrumb,
       BCDynamicNamedLink(identity,"Summary".clusterRoute)),
+    "Schedule Leader Election" -> IndexedSeq(
+      "Clusters".baseRouteBreadCrumb,
+      BCDynamicNamedLink(identity,"Summary".clusterRoute)),
     "Reassign Partitions" -> IndexedSeq(
       "Clusters".baseRouteBreadCrumb,
       BCDynamicNamedLink(identity,"Summary".clusterRoute)),

--- a/app/models/navigation/Menus.scala
+++ b/app/models/navigation/Menus.scala
@@ -5,7 +5,7 @@
 
 package models.navigation
 
-import features.{KMTopicManagerFeature, KMClusterManagerFeature, KMPreferredReplicaElectionFeature, KMReassignPartitionsFeature, ApplicationFeatures}
+import features.{KMTopicManagerFeature, KMClusterManagerFeature, KMPreferredReplicaElectionFeature, KMScheduleLeaderElectionFeature, KMReassignPartitionsFeature, ApplicationFeatures}
 import kafka.manager.features.{KMLogKafkaFeature, ClusterFeatures}
 
 /**
@@ -50,6 +50,12 @@ class Menus(implicit applicationFeatures: ApplicationFeatures) {
     } else None
   }
   
+  private[this] def scheduleLeaderElectionMenu(cluster: String) : Option[Menu] = {
+    if (applicationFeatures.features(KMScheduleLeaderElectionFeature)) {
+      Option("Schedule Leader Election".clusterMenu(cluster))
+    } else None
+  }
+
   private[this] def reassignPartitionsMenu(cluster: String) : Option[Menu] = {
     if (applicationFeatures.features(KMReassignPartitionsFeature)) {
       Option("Reassign Partitions".clusterMenu(cluster))
@@ -77,6 +83,7 @@ class Menus(implicit applicationFeatures: ApplicationFeatures) {
       brokersMenu(cluster),
       topicMenu(cluster),
       preferredReplicaElectionMenu(cluster),
+      scheduleLeaderElectionMenu(cluster),
       reassignPartitionsMenu(cluster),
       consumersMenu(cluster),
       logKafkaMenu(cluster, clusterFeatures)

--- a/app/models/navigation/QuickRoutes.scala
+++ b/app/models/navigation/QuickRoutes.scala
@@ -27,6 +27,7 @@ object QuickRoutes {
     "List" -> controllers.routes.Topic.topics,
     "Create" -> controllers.routes.Topic.createTopic,
     "Preferred Replica Election" -> controllers.routes.PreferredReplicaElection.preferredReplicaElection,
+    "Schedule Leader Election" -> controllers.routes.PreferredReplicaElection.scheduleRunElection,
     "Reassign Partitions" -> controllers.routes.ReassignPartitions.reassignPartitions,
     "Logkafkas" -> controllers.routes.Logkafka.logkafkas,
     "List Logkafka" -> controllers.routes.Logkafka.logkafkas,

--- a/app/views/scheduleLeaderElection.scala.html
+++ b/app/views/scheduleLeaderElection.scala.html
@@ -1,0 +1,56 @@
+@*
+* Copyright 2015 Yahoo Inc. Licensed under the Apache License, Version 2.0
+* See accompanying LICENSE file.
+*@
+@import scalaz.{\/}
+@import b3.vertical.fieldConstructor
+@(cluster:String, errorOrStatus: kafka.manager.ApiError \/ kafka.manager.model.ActorModel.TopicList, status: String, timePeriod: Int
+)(implicit af: features.ApplicationFeatures, messages: play.api.i18n.Messages, menus: models.navigation.Menus)
+
+@theMenu = {
+@views.html.navigation.clusterMenu(cluster,"Schedule Leader Election","",menus.clusterMenus(cluster)(
+    errorOrStatus.map(_.clusterContext.clusterFeatures).getOrElse(kafka.manager.features.ClusterFeatures.default)))
+}
+
+@main(
+    "Schedule Leader Election",
+    menu = theMenu,
+    breadcrumbs=views.html.navigation.breadCrumbs(models.navigation.BreadCrumbs.withViewAndCluster("Schedule Leader Election",cluster))) {
+    <div class="col-md-6 un-pad-me">
+        <div class="panel panel-default">
+            <div class="panel-heading"><h3>Schedule Leader Election</h3></div>
+            <div class="col-md-6">
+                @features.app(features.KMScheduleLeaderElectionFeature) {
+                    <div>
+                    @if(timePeriod == 0) {
+                        @b3.form(routes.PreferredReplicaElection.handleScheduleRunElection(cluster)) {
+                            <input type="number" min="1" name="timePeriod" class="form-control col-md-8" placeholder="Time for scheduling (in min)" required />
+                            <fieldset>
+                            @b3.submit('class -> "btn btn-primary"){ Schedule Preferred Replica Election }
+                            </fieldset>
+                        }
+                    } else {
+                        @b3.form(routes.PreferredReplicaElection.cancelScheduleRunElection(cluster)) {
+                            <fieldset>
+                            @b3.submit('class -> "btn btn-primary"){ Cancel Preferred Replica Election }
+                            </fieldset>
+                        }
+                    }
+                    </div>
+                }
+
+            </div>
+        </div>
+
+        <div class="row col-md-12">
+            <div class="alert alert-warning" role="alert">
+            @if(timePeriod == 0) {
+                @status
+            } else {
+                @status (every @timePeriod minutes)
+            }
+            </div>
+        </div>
+    </div>
+}
+

--- a/app/views/scheduleLeaderElection.scala.html
+++ b/app/views/scheduleLeaderElection.scala.html
@@ -3,9 +3,8 @@
 * See accompanying LICENSE file.
 *@
 @import scalaz.{\/}
-@import b3.vertical.fieldConstructor
 @(cluster:String, errorOrStatus: kafka.manager.ApiError \/ kafka.manager.model.ActorModel.TopicList, status: String, timePeriod: Int
-)(implicit af: features.ApplicationFeatures, messages: play.api.i18n.Messages, menus: models.navigation.Menus)
+)(implicit af: features.ApplicationFeatures, messages: play.api.i18n.Messages, menus: models.navigation.Menus, request:RequestHeader)
 
 @theMenu = {
 @views.html.navigation.clusterMenu(cluster,"Schedule Leader Election","",menus.clusterMenus(cluster)(
@@ -17,22 +16,22 @@
     menu = theMenu,
     breadcrumbs=views.html.navigation.breadCrumbs(models.navigation.BreadCrumbs.withViewAndCluster("Schedule Leader Election",cluster))) {
     <div class="col-md-6 un-pad-me">
-        <div class="panel panel-default">
-            <div class="panel-heading"><h3>Schedule Leader Election</h3></div>
+        <div class="card">
+            <div class="card-header"><h3>Schedule Leader Election</h3></div>
             <div class="col-md-6">
                 @features.app(features.KMScheduleLeaderElectionFeature) {
                     <div>
                     @if(timePeriod == 0) {
-                        @b3.form(routes.PreferredReplicaElection.handleScheduleRunElection(cluster)) {
+                        @b4.vertical.form(routes.PreferredReplicaElection.handleScheduleRunElection(cluster)) { implicit fc =>
                             <input type="number" min="1" name="timePeriod" class="form-control col-md-8" placeholder="Time for scheduling (in min)" required />
                             <fieldset>
-                            @b3.submit('class -> "btn btn-primary"){ Schedule Preferred Replica Election }
+                            @b4.submit('class -> "btn btn-primary"){ Schedule Preferred Replica Election }
                             </fieldset>
                         }
                     } else {
-                        @b3.form(routes.PreferredReplicaElection.cancelScheduleRunElection(cluster)) {
+                        @b4.vertical.form(routes.PreferredReplicaElection.cancelScheduleRunElection(cluster)) { implicit fc =>
                             <fieldset>
-                            @b3.submit('class -> "btn btn-primary"){ Cancel Preferred Replica Election }
+                            @b4.submit('class -> "btn btn-primary"){ Cancel Preferred Replica Election }
                             </fieldset>
                         }
                     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -25,7 +25,7 @@ kafka-manager.zkhosts="kafka-manager-zookeeper:2181"
 kafka-manager.zkhosts=${?ZK_HOSTS}
 pinned-dispatcher.type="PinnedDispatcher"
 pinned-dispatcher.executor="thread-pool-executor"
-application.features=["KMClusterManagerFeature","KMTopicManagerFeature","KMPreferredReplicaElectionFeature","KMReassignPartitionsFeature"]
+application.features=["KMClusterManagerFeature","KMTopicManagerFeature","KMPreferredReplicaElectionFeature","KMReassignPartitionsFeature", "KMScheduleLeaderElectionFeature"]
 
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]

--- a/conf/routes
+++ b/conf/routes
@@ -21,6 +21,10 @@ GET    /clusters/:c/consumers/:g/type/:ct                   controllers.Consumer
 GET    /clusters/:c/consumers/:g/topic/:t/type/:ct          controllers.Consumer.consumerAndTopic(c: String, g:String, t:String, ct: String)
 GET    /clusters/:c/leader                                  controllers.PreferredReplicaElection.preferredReplicaElection(c:String)
 POST   /clusters/:c/leader                                  controllers.PreferredReplicaElection.handleRunElection(c:String)
+GET    /clusters/:c/leader/schedule                         controllers.PreferredReplicaElection.scheduleRunElection(c:String)
+POST   /clusters/:c/leader/schedule                         controllers.PreferredReplicaElection.handleScheduleRunElection(c:String)
+GET    /clusters/:c/leader/schedule/cancel                  controllers.PreferredReplicaElection.scheduleRunElection(c:String)
+POST   /clusters/:c/leader/schedule/cancel                  controllers.PreferredReplicaElection.cancelScheduleRunElection(c:String)
 GET    /clusters/:c/assignment                              controllers.ReassignPartitions.reassignPartitions(c:String)
 POST   /clusters/:c/assignment                              controllers.ReassignPartitions.handleOperation(c:String,t:String)
 GET    /clusters/:c/assignment/confirm                      controllers.ReassignPartitions.confirmAssignment(c:String,t:String)
@@ -62,6 +66,10 @@ GET    /api/status/:c/:t/unavailablePartitions              controllers.api.Kafk
 GET    /api/status/:cluster/:consumer/:topic/:consumerType/topicSummary   controllers.api.KafkaStateCheck.topicSummaryAction(cluster:String, consumer:String, topic:String, consumerType:String)
 GET    /api/status/:cluster/:consumer/:consumerType/groupSummary          controllers.api.KafkaStateCheck.groupSummaryAction(cluster:String, consumer:String, consumerType:String)
 GET    /api/status/:cluster/consumersSummary                controllers.api.KafkaStateCheck.consumersSummaryAction(cluster:String)
+
+GET    /api/clusters/:c/leader/scheduledInterval            controllers.PreferredReplicaElection.handleScheduledIntervalAPI(c:String)
+POST   /api/clusters/:c/leader/schedule                     controllers.PreferredReplicaElection.handleScheduleRunElectionAPI(c:String)
+POST   /api/clusters/:c/leader/schedule/cancel              controllers.PreferredReplicaElection.cancelScheduleRunElectionAPI(c:String)
 
 # Versioned Assets
 GET    /vassets/*file                                       controllers.Assets.versioned(path="/public", file: Asset)

--- a/test/kafka/manager/TestKafkaManager.scala
+++ b/test/kafka/manager/TestKafkaManager.scala
@@ -7,6 +7,7 @@ package kafka.manager
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicBoolean
 
+import akka.actor.Cancellable
 import com.typesafe.config.{Config, ConfigFactory}
 import kafka.manager.features.KMDeleteTopicFeature
 import kafka.manager.model._
@@ -252,6 +253,31 @@ class TestKafkaManager extends CuratorAwareTest with BaseTest {
     val result = Await.result(future,duration)
     assert(result.isRight === true)
     println(result.toOption.get)
+  }
+
+  test("schedule preferred leader election") {
+    val topicList = getTopicList()
+    kafkaManager.schedulePreferredLeaderElection("dev",topicList.list.toSet, 1)
+    assert(
+      kafkaManager.pleCancellable.contains("dev"),
+      "Scheduler not being persisted against the cluster name in KafkaManager instance. Is the task even getting scheduled?"
+    )
+    assert(
+      kafkaManager.pleCancellable("dev")._1.isInstanceOf[Option[Cancellable]],
+      "Some(system.scheduler.schedule) instance not being stored in KafkaManager instance. This is required for cancelling."
+    )
+  }
+
+  test("cancel scheduled preferred leader election") {
+    // For cancelling it is necessary for the task to be scheduled
+    if(!(kafkaManager.pleCancellable.contains("dev") && kafkaManager.pleCancellable("dev")._1.isInstanceOf[Option[Cancellable]])){
+      kafkaManager.schedulePreferredLeaderElection("dev",getTopicList().list.toSet, 1)
+    }
+    kafkaManager.cancelPreferredLeaderElection("dev")
+    assert(
+      !kafkaManager.pleCancellable.contains("dev"),
+      "Scheduler cluster name is not being removed from KafkaManager instance. Is the task even getting cancelled?"
+    )
   }
 
   test("generate partition assignments") {


### PR DESCRIPTION
We recently worked on adding a feature (new tab & REST APIs) to Kafka Manager which would allow users to schedule the replica leader election. We thought it might be helpful for other users as well so would like to share it here and preferably merge it upstream ([yahoo/kafka-manager](https://github.com/yahoo/kafka-manager)).

I am quite new to Scala/Akka so I would appreciate if you could let me know what changes you'd like to see in this patch and how it can be best used to improve Kafka Manager.