### PR TITLE
Fix LDAP authentication does not support colons in password

### DIFF
--- a/app/controllers/BasicAuthenticationFilter.scala
+++ b/app/controllers/BasicAuthenticationFilter.scala
@@ -172,7 +172,7 @@ case class LDAPAuthenticator(config: LDAPAuthenticationConfig)(implicit val mat:
       authorization.split("\\s+").toList match {
         case "Basic" :: base64Hash :: Nil => {
           val credentials = new String(org.apache.commons.codec.binary.Base64.decodeBase64(base64Hash.getBytes))
-          credentials.split(":").toList match {
+          credentials.split(":", 2).toList match {
             case username :: password :: Nil => Some(username -> password)
             case _ => None
           }


### PR DESCRIPTION
Fixes #696 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
