### PR TITLE
Upgrade dependencies & separate common version literals into val + etc

### DIFF
--- a/app/kafka/manager/actor/cluster/KafkaStateActor.scala
+++ b/app/kafka/manager/actor/cluster/KafkaStateActor.scala
@@ -130,7 +130,7 @@ case class KafkaAdminClientActor(config: KafkaAdminClientActorConfig) extends Ba
                   val options = new DescribeConsumerGroupsOptions
                   options.timeoutMs(1000)
                   client.describeConsumerGroups(groupList.asJava, options).all().whenComplete {
-                    (mapGroupDescription, error) => mapGroupDescription.asScala.foreach {
+                    (mapGroupDescription, _) => mapGroupDescription.asScala.foreach {
                       case (group, desc) =>
                         enqueue.offer(group -> desc.members().asScala.map(m => MemberMetadata.from(group, desc, m)).toList)
                     }
@@ -438,7 +438,7 @@ object ConsumerInstanceSubscriptions extends Logging {
     import org.json4s.jackson.JsonMethods.parse
     import org.json4s.scalaz.JsonScalaz.field
     val json = parse(jsonString)
-    val subs: Map[String, Int] = field[Map[String,Int]]("subscription")(json).fold({ e =>
+    val subs: Map[String, Int] = field[Map[String,Int]]("subscription")(json).fold({ _ =>
       error(s"[consumer=$consumer] Failed to parse consumer instance subscriptions : $id : $jsonString"); Map.empty}, identity)
     new ConsumerInstanceSubscriptions(id, subs)
   }
@@ -483,10 +483,8 @@ trait OffsetCache extends Logging {
     // Get partition leader broker information
     val optPartitionsWithLeaders : Option[List[(Int, Option[BrokerIdentity])]] = getTopicPartitionLeaders(topic)
 
-    val clientId = "partitionOffsetGetter"
     val time = -1
     val nOffsets = 1
-    val simpleConsumerBufferSize = 256 * 1024
     val currentActiveBrokerSet:Set[String] = getBrokerList().list.map(_.host).toSet
 
     val partitionsByBroker = optPartitionsWithLeaders.map {
@@ -672,13 +670,13 @@ trait OffsetCache extends Logging {
     val (partitionOffsets, partitionOwners) = consumerType match {
       case ZKManagedConsumer =>
         val partitionOffsets = for {
-          td <- optTopic
+          _ <- optTopic
           tpi <- optTpi
         } yield {
           readConsumerOffsetByTopicPartition(consumer, topic, tpi)
         }
         val partitionOwners = for {
-          td <- optTopic
+          _ <- optTopic
           tpi <- optTpi
         } yield {
           readConsumerOwnerByTopicPartition(consumer, topic, tpi)
@@ -686,13 +684,13 @@ trait OffsetCache extends Logging {
         (partitionOffsets, partitionOwners)
       case KafkaManagedConsumer =>
         val partitionOffsets = for {
-          td <- optTopic
+          _ <- optTopic
           tpi <- optTpi
         } yield {
           readKafkaManagedConsumerOffsetByTopicPartition(consumer, topic, tpi)
         }
         val partitionOwners = for {
-          td <- optTopic
+          _ <- optTopic
           tpi <- optTpi
         } yield {
           readKafkaManagedConsumerOwnerByTopicPartition(consumer, topic, tpi)
@@ -818,7 +816,7 @@ case class OffsetCacheActive(curator: CuratorFramework
       IndexedSeq.empty[ConsumerNameAndType]
     } { data: java.util.Map[String, ChildData] =>
       data.asScala.filter{
-        case (consumer, childData) =>
+        case (_, childData) =>
           if (clusterContext.config.filterConsumers)
           // Defining "inactive consumer" as a consumer that is missing one of three children ids/ offsets/ or owners/
             childData.getStat.getNumChildren > 2
@@ -1203,7 +1201,7 @@ class KafkaStateActor(config: KafkaStateActorConfig) extends BaseClusterQueryCom
     states.map(_.map{case (part, state) =>
       val partition = part.toInt
       val descJson = parse(state)
-      val leaderID = field[Int]("leader")(descJson).fold({ e =>
+      val leaderID = field[Int]("leader")(descJson).fold({ _ =>
         log.error(s"[topic=$topic] Failed to get partitions from topic json $state"); 0}, identity)
       val leader = targetBrokers.find(_.id == leaderID)
       (partition, leader)
@@ -1444,7 +1442,7 @@ class KafkaStateActor(config: KafkaStateActorConfig) extends BaseClusterQueryCom
                 if (shutdown) {
                   return
                 }
-                var optPartitionsWithLeaders : Option[List[(Int, Option[BrokerIdentity])]] = getPartitionLeaders(topic)
+                val optPartitionsWithLeaders : Option[List[(Int, Option[BrokerIdentity])]] = getPartitionLeaders(topic)
                 optPartitionsWithLeaders match {
                   case Some(leaders) =>
                     leaders.foreach(leader => {
@@ -1492,7 +1490,7 @@ class KafkaStateActor(config: KafkaStateActorConfig) extends BaseClusterQueryCom
                 try {
                   kafkaConsumer = Option(new KafkaConsumer(consumerProperties))
                   val request = tpList.map(f => new TopicPartition(f._1.topic(), f._1.partition()))
-                  var tpOffsetMapOption = kafkaConsumer.map(_.endOffsets(request.asJavaCollection).asScala)
+                  val tpOffsetMapOption = kafkaConsumer.map(_.endOffsets(request.asJavaCollection).asScala)
 
                   var topicOffsetMap: Map[Int, Long] = null
                   tpOffsetMapOption.foreach(tpOffsetMap => tpOffsetMap.keys.foreach(tp => {

--- a/build.sbt
+++ b/build.sbt
@@ -21,35 +21,40 @@ assemblyMergeStrategy in assembly := {
   case other => (assemblyMergeStrategy in assembly).value(other)
 }
 
+val akkaVersion = "2.6.2"
+val curatorVersion = "4.2.0"
+val json4sVersion = "3.6.7"
+val kafkaVersion = "2.4.0"
+
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.5.19",
-  "com.typesafe.akka" %% "akka-slf4j" % "2.5.19",
+  "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+  "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
   "com.google.code.findbugs" % "jsr305" % "3.0.2",
-  "org.webjars" %% "webjars-play" % "2.6.3",
-  "org.webjars" % "bootstrap" % "4.3.1",
-  "org.webjars" % "jquery" % "3.3.1-2",
+  "org.webjars" %% "webjars-play" % "2.8.0",
+  "org.webjars" % "bootstrap" % "4.4.1",
+  "org.webjars" % "jquery" % "3.4.0",
   "org.webjars" % "backbonejs" % "1.3.3",
   "org.webjars" % "underscorejs" % "1.9.0",
   "org.webjars" % "dustjs-linkedin" % "2.7.2",
   "org.webjars" % "octicons" % "4.3.0",
-  "org.apache.curator" % "curator-framework" % "2.12.0" exclude("log4j","log4j") exclude("org.slf4j", "slf4j-log4j12") force(),
-  "org.apache.curator" % "curator-recipes" % "2.12.0" exclude("log4j","log4j") exclude("org.slf4j", "slf4j-log4j12") force(),
-  "org.json4s" %% "json4s-jackson" % "3.6.5",
-  "org.json4s" %% "json4s-scalaz" % "3.6.5",
-  "org.slf4j" % "log4j-over-slf4j" % "1.7.25",
-  "com.adrianhurt" %% "play-bootstrap" % "1.4-P26-B4" exclude("com.typesafe.play", "*"),
+  "org.apache.curator" % "curator-framework" % curatorVersion exclude("log4j","log4j") exclude("org.slf4j", "slf4j-log4j12") force(),
+  "org.apache.curator" % "curator-recipes" % curatorVersion exclude("log4j","log4j") exclude("org.slf4j", "slf4j-log4j12") force(),
+  "org.json4s" %% "json4s-jackson" % json4sVersion,
+  "org.json4s" %% "json4s-scalaz" % json4sVersion,
+  "org.slf4j" % "log4j-over-slf4j" % "1.7.30",
+  "com.adrianhurt" %% "play-bootstrap" % "1.5.1-P27-B3" exclude("com.typesafe.play", "*"),
   "org.clapper" %% "grizzled-slf4j" % "1.3.3",
-  "org.apache.kafka" %% "kafka" % "2.4.0" exclude("log4j","log4j") exclude("org.slf4j", "slf4j-log4j12") force(),
-  "org.apache.kafka" % "kafka-streams" % "2.2.0",
-  "com.beachape" %% "enumeratum" % "1.5.13",
-  "com.github.ben-manes.caffeine" % "caffeine" % "2.6.2",
-  "com.typesafe.play" %% "play-logback" % "2.6.21",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "test",
-  "org.apache.curator" % "curator-test" % "2.12.0" % "test",
-  "org.mockito" % "mockito-core" % "1.10.19" % "test",
+  "org.apache.kafka" %% "kafka" % kafkaVersion exclude("log4j","log4j") exclude("org.slf4j", "slf4j-log4j12") force(),
+  "org.apache.kafka" % "kafka-streams" % kafkaVersion,
+  "com.beachape" %% "enumeratum" % "1.5.14",
+  "com.github.ben-manes.caffeine" % "caffeine" % "2.8.0",
+  "com.typesafe.play" %% "play-logback" % "2.8.0",
+  "org.scalatest" %% "scalatest" % "3.1.0" % "test",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % "test",
+  "org.apache.curator" % "curator-test" % curatorVersion % "test",
+  "org.mockito" % "mockito-core" % "3.2.4" % "test",
   "com.yammer.metrics" % "metrics-core" % "2.2.0" force(),
-  "com.unboundid" % "unboundid-ldapsdk" % "4.0.9"
+  "com.unboundid" % "unboundid-ldapsdk" % "4.0.14"
 )
 
 routesGenerator := InjectedRoutesGenerator


### PR DESCRIPTION
1. Separate common version literals into val. (`akkaVersion`, `curatorVersion`, `json4sVersion`, `kafkaVersion`)
2. Upgrade dependencies: akka, webjars-play, curator, etc.
3. Trivial code clean-ups: remove unused functions (e.g., `GroupMetadataManager.parseOffsets`), vals, etc.