### PR TITLE
Fix Build Failure at 3.0.0.4

### DIFF
--- a/app/kafka/manager/package.scala
+++ b/app/kafka/manager/package.scala
@@ -28,6 +28,6 @@ package object manager {
   }
 
   implicit class PropertiesHelper(p: java.util.Properties) {
-    def asMap: java.util.Map[_, _] = p.asInstanceOf[java.util.Map[_, _]]
+    def asMap: java.util.Map[Object, Object] = p.asInstanceOf[java.util.Map[Object, Object]]
   }
 }

--- a/app/kafka/manager/utils/zero10/LogConfig.scala
+++ b/app/kafka/manager/utils/zero10/LogConfig.scala
@@ -309,7 +309,7 @@ object LogConfig extends TopicConfigs {
     */
   def fromProps(defaults: java.util.Map[_ <: Object, _ <: Object], overrides: Properties): LogConfig = {
     val props = new Properties()
-    props.putAll(defaults.asInstanceOf[java.util.Map[_,_]])
+    props.putAll(defaults.asInstanceOf[java.util.Map[Object, Object]])
     props.putAll(overrides.asMap)
     LogConfig(props)
   }

--- a/app/kafka/manager/utils/zero11/LogConfig.scala
+++ b/app/kafka/manager/utils/zero11/LogConfig.scala
@@ -269,7 +269,7 @@ object LogConfig extends TopicConfigs {
     */
   def fromProps(defaults: java.util.Map[_ <: Object, _ <: Object], overrides: Properties): LogConfig = {
     val props = new Properties()
-    props.putAll(defaults.asInstanceOf[java.util.Map[_, _]])
+    props.putAll(defaults.asInstanceOf[java.util.Map[Object, Object]])
     props.putAll(overrides.asMap)
     LogConfig(props)
   }

--- a/app/kafka/manager/utils/zero90/LogConfig.scala
+++ b/app/kafka/manager/utils/zero90/LogConfig.scala
@@ -173,7 +173,7 @@ object LogConfig extends TopicConfigs {
     */
   def fromProps(defaults: java.util.Map[_ <: Object, _ <: Object], overrides: Properties): LogConfig = {
     val props = new Properties()
-    props.putAll(defaults.asInstanceOf[java.util.Map[_, _]])
+    props.putAll(defaults.asInstanceOf[java.util.Map[Object, Object]])
     props.putAll(overrides.asMap)
     LogConfig(props)
   }

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,6 @@ libraryDependencies ++= Seq(
   "org.apache.kafka" % "kafka-streams" % "2.2.0",
   "com.beachape" %% "enumeratum" % "1.5.13",
   "com.github.ben-manes.caffeine" % "caffeine" % "2.6.2",
-  "com.typesafe.play" %% "play-logback" % "2.6.21",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "test",
   "org.apache.curator" % "curator-test" % "2.12.0" % "test",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.2.8


### PR DESCRIPTION
This PR fixes current build failure by:

1. Revert `sbt.version` into 1.2.8, the version used at the last stable release.

    With `sbt.version` >= 1.3.0, `sbt test` fails with `java.lang.ClassNotFoundException: com.fasterxml.jackson.core.JsonFactory`.

2. Remove duplicated dependency: `com.typesafe.play:play-logback` is provided by `com.typesafe.play:sbt-plugin`.
3. Fix compliation failures caused by type casting.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
