### PR TITLE
Create a new option to trust all non-expired certificates during LDAP authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ LDAP support is through the basic authentication filter.
 
 4. (Optional) Limit access to a specific LDAP Group
 - basicAuthentication.ldap.group-filter=< LDAP group filter>
+- basicAuthentication.ldap.ssl-trust-all=< Boolean flag to allow non-expired invalid certificates>
 
 #### Example (Online LDAP Test Server):
 
@@ -160,6 +161,7 @@ LDAP support is through the basic authentication filter.
 - basicAuthentication.ldap.group-filter="cn=allowed-group,ou=groups,dc=example,dc=com"
 - basicAuthentication.ldap.connection-pool-size=10
 - basicAuthentication.ldap.ssl=false
+- basicAuthentication.ldap.ssl-trust-all=false
 
 
 Deployment

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,6 +62,8 @@ basicAuthentication.ldap.connection-pool-size=10
 basicAuthentication.ldap.connection-pool-size=${?KAFKA_MANAGER_LDAP_CONNECTION_POOL_SIZE}
 basicAuthentication.ldap.ssl=false
 basicAuthentication.ldap.ssl=${?KAFKA_MANAGER_LDAP_SSL}
+basicAuthentication.ldap.ssl-trust-all=false
+basicAuthentication.ldap.ssl-trust-all=${?KAFKA_MANAGER_LDAP_SSL_TRUST_ALL}
 
 basicAuthentication.username="admin"
 basicAuthentication.username=${?KAFKA_MANAGER_USERNAME}


### PR DESCRIPTION

Signed-off-by: Parth Kolekar <parthkolekar@indeed.com>


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
