### PR TITLE
cluster new/edit page duplicate security protocol SASL_PLAINTEXT fix

### DIFF
--- a/app/kafka/manager/model/model.scala
+++ b/app/kafka/manager/model/model.scala
@@ -485,7 +485,7 @@ case object PLAINTEXT extends SecurityProtocol {
 object SecurityProtocol {
   private[this] val typesMap: Map[String, SecurityProtocol] = Map(
     SASL_PLAINTEXT.stringId -> SASL_PLAINTEXT
-    , PLAINTEXTSASL.stringId -> SASL_PLAINTEXT
+    , PLAINTEXTSASL.stringId -> PLAINTEXTSASL
     , SASL_SSL.stringId -> SASL_SSL
     , SSL.stringId -> SSL
     , PLAINTEXT.stringId -> PLAINTEXT


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

from https://github.com/yahoo/CMAK/commit/08a03329607026dd09381af12b492a22ce264119 introduce PLAINTEXTSASL , but mistakenlly let it point to SASL_PLAINTEXT instead of PLAINTEXTSASL , which cause duplicate SASL_PLAINTEXT displayed in list and PLAINTEXTSASL  is also can't be really set.