### PR TITLE
Set RPM compression to preserve backwards compatability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,4 +136,9 @@ rpmUrl := Some("https://github.com/yahoo/cmak")
 rpmLicense := Some("Apache")
 rpmGroup := Some("cmak")
 
+import RpmConstants._
+maintainerScripts in Rpm := maintainerScriptsAppend((maintainerScripts in Rpm).value)(
+   Pre -> "%define _binary_payload w9.xzdio"
+)
+
 /* End RPM Settings */


### PR DESCRIPTION
Building RPM on newer systems defaults RPM compression is ZSTD which prevents older systems from installing rpm


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
