### PR TITLE
Sort topics in consumer view

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,13 +7,13 @@ logLevel := Level.Info
 
 resolvers += Resolver.url(
   "bintray-sbt-plugin-releases",
-  url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
+  url("https://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
     Resolver.ivyStylePatterns)
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 
 // The Typesafe repository
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.21")


### PR DESCRIPTION
This will sort the list of topics a consumer is assigned to.

Two minor changes as well, change the repositories to https (removes the sbt warning about that) and some whitespace changes, which my editor is doing by default. If required I can revert those easily.

Thank you!


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
