### PR TITLE
manual assign partition page sorted by id 

### DIFF
--- a/app/controllers/ReassignPartitions.scala
+++ b/app/controllers/ReassignPartitions.scala
@@ -175,7 +175,7 @@ class ReassignPartitions (val cc: ControllerComponents, val kafkaManagerContext:
   private[this] def flattenTopicIdentity(td: TopicIdentity) = {
     (td.topic, td.partitionsIdentity.toList.map { case (partition, identity) =>
       (partition, identity.replicas.toList)
-    })
+    }.sortBy(p=>p._1))
   }
 
   def manualAssignments(c: String, t: String): Action[AnyContent] = Action.async { implicit request:RequestHeader =>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

currentlly partions display in random order, may be map hash order.
this little change show partions in id order which is much friendlly for human