### PR TITLE
#monitoring add monitoring api for broker status

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -79,3 +79,7 @@ GET    /assets/*file                                        controllers.Assets.a
 
 # Ping / Health Check
 GET    /api/health                                          controllers.ApiHealth.ping
+
+# Monitoring Broker Status
+GET    /api/status/:c/monitoring                            controllers.api.KafkaStateCheck.monitoring(c:String)
+GET    /api/status/:c/:b/brokermonitoring                   controllers.api.KafkaStateCheck.brokermonitoring(c:String, b:Int)


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

I added monitoring APIs to get broker's status easily.
It is useful when JMX is enabled.

You can get broker's status by call /api/status/$clusterName/$brokerId/brokermonitoring

I'm bad at scala, so it's very hard coded.